### PR TITLE
The Damntrening

### DIFF
--- a/BetterSMT.cs
+++ b/BetterSMT.cs
@@ -216,7 +216,7 @@ public class BetterSMT : BaseUnityPlugin {
         EmployeeRerolls = Config.Bind("Random Features","Employee Rerolls",false,new ConfigDescription("Gives you unlimited rerolls to change your employees"));
         OneClickCheckMark = Config.Bind("Random Features","Surveillance Camera One Click",false,new ConfigDescription("Makes all customers one click when using security console"));
         AllowFreePlacement = Config.Bind("Random Features","Disable Placement Blocking",false,new ConfigDescription("Enables or disables you to place structures wherever in the main area, even overlapping"));
-        CheatPlacement = Config.Bind("Random Features","Disable PLacement Checks",false,new ConfigDescription("Similar to Free Placement, but allows building anywhere and everywhere"));
+        CheatPlacement = Config.Bind("Random Features","Disable Placement Checks",false,new ConfigDescription("Similar to Free Placement, but allows building anywhere and everywhere, for free"));
         ProductStacking = Config.Bind("Random Features","Enable product stacking",false,new ConfigDescription("Enables or disables most products in the game to stack on shelves"));
         EnablePalletDisplaysPerk = Config.Bind("Random Features","Enable pallet displays",false,new ConfigDescription("Enables pallet displays without unlocking the perk."));
         ReplaceCommasWithPeriods = Config.Bind("Random Features","Replace commas with periods",false,new ConfigDescription("Changes all commas in the game into periods."));

--- a/Patches/ManagerBlackboardPatch.cs
+++ b/Patches/ManagerBlackboardPatch.cs
@@ -130,29 +130,28 @@ public class ManagerBlackboardPatch {
     [HarmonyPatch("AddShoppingListProduct")]
     [HarmonyPrefix]
     public static bool AddShoppingListProductPatch(ManagerBlackboard __instance,int productID,float boxPrice) {
-        if(!BetterSMT.ReplaceCommasWithPeriods.Value) {
-
-            ProductListing component = __instance.GetComponent<ProductListing>();
-            GameObject gameObject = Object.Instantiate(__instance.UIShoppingListPrefab,__instance.shoppingListParent.transform);
-
-            string key = "product" + productID;
-            string localizationString = LocalizationManager.instance.GetLocalizationString(key);
-            gameObject.transform.Find("ProductName").GetComponent<TextMeshProUGUI>().text = localizationString;
-
-            GameObject obj = component.productPrefabs[productID];
-            string productBrand = obj.GetComponent<Data_Product>().productBrand;
-            gameObject.transform.Find("BrandName").GetComponent<TextMeshProUGUI>().text = productBrand;
-
-            int maxItemsPerBox = obj.GetComponent<Data_Product>().maxItemsPerBox;
-            gameObject.transform.Find("BoxQuantity").GetComponent<TextMeshProUGUI>().text = "x" + maxItemsPerBox.ToString("F2",CultureInfo.InvariantCulture);
-            gameObject.transform.Find("BoxPrice").GetComponent<TextMeshProUGUI>().text = $" ${boxPrice.ToString("F2",CultureInfo.InvariantCulture)}";
-
-            gameObject.GetComponent<InteractableData>().thisSkillIndex = productID;
-
-            _ = __instance.StartCoroutine(CalculateShoppingListTotalOverride(__instance));
-            return false;
-        } else {
+        if (!BetterSMT.ReplaceCommasWithPeriods.Value) {
             return true;
         }
+
+        ProductListing component = __instance.GetComponent<ProductListing>();
+        GameObject gameObject = Object.Instantiate(__instance.UIShoppingListPrefab,__instance.shoppingListParent.transform);
+
+        string key = "product" + productID;
+        string localizationString = LocalizationManager.instance.GetLocalizationString(key);
+        gameObject.transform.Find("ProductName").GetComponent<TextMeshProUGUI>().text = localizationString;
+
+        GameObject obj = component.productPrefabs[productID];
+        string productBrand = obj.GetComponent<Data_Product>().productBrand;
+        gameObject.transform.Find("BrandName").GetComponent<TextMeshProUGUI>().text = productBrand;
+
+        int maxItemsPerBox = obj.GetComponent<Data_Product>().maxItemsPerBox;
+        gameObject.transform.Find("BoxQuantity").GetComponent<TextMeshProUGUI>().text = "x" + maxItemsPerBox.ToString("F2",CultureInfo.InvariantCulture);
+        gameObject.transform.Find("BoxPrice").GetComponent<TextMeshProUGUI>().text = $" ${boxPrice.ToString("F2",CultureInfo.InvariantCulture)}";
+
+        gameObject.GetComponent<InteractableData>().thisSkillIndex = productID;
+
+        _ = __instance.StartCoroutine(CalculateShoppingListTotalOverride(__instance));
+        return false;
     }
 }

--- a/Patches/ProductListingPatch.cs
+++ b/Patches/ProductListingPatch.cs
@@ -11,9 +11,16 @@ namespace BetterSMT.Patches {
         [HarmonyPostfix]
         [HarmonyPatch(typeof(ProductListing),"OnStartClient")]
         public static void Postfix(ProductListing __instance) {
-            foreach(GameObject prefab in __instance.productPrefabs) {
-                Data_Product data = prefab.GetComponent<Data_Product>();
+            if (BetterSMT.MaxBoxSize.Value == (int)BetterSMT.MaxBoxSize.DefaultValue){
+                return;
+            }
 
+            foreach (GameObject prefab in __instance.productPrefabs) {
+                if (prefab == null) {
+                    //Compatibility with Custom Products mod leaving empty spaces.
+                    continue;
+                }
+                Data_Product data = prefab.GetComponent<Data_Product>();
                 data.maxItemsPerBox *= BetterSMT.MaxBoxSize.Value;
             }
         }


### PR DESCRIPTION
- AllowFreePlacement and CheatPlacement settings each behave the same while placing buildables or decorations. Now with CheatPlacement enabled, building costs are free. Previously it used to be free with decorations, but buildables were not, and both settings let you go into the red.
- Made a transpiler to disable building costs with CheatPlacement, because Mitche loves them.
- Fixed exception with the Custom Furniture mod installed.
- Fixed not being able to order when the setting ReplaceCommasWithPeriods is disabled.